### PR TITLE
Calculate delivery date range using only working days

### DIFF
--- a/estimated-delivery-woocommerce.php
+++ b/estimated-delivery-woocommerce.php
@@ -269,6 +269,23 @@ if(!defined('EDWCore')) {
 
             require_once(EDW_PATH . 'views/options.php');
         }
+        
+        private function edw_get_working_day_date($disabledDays, $daysToAdd, $dateCheck, $iteration = 0) {
+            if(count($disabledDays) == 7) {
+                return false;
+            }
+            if($iteration == $daysToAdd) {
+              return $dateCheck;
+            }
+
+            $dateCheck = wp_date('Y-m-d', strtotime($dateCheck . " + 1 days"));
+
+            $filterDisabled = date('D', strtotime($dateCheck));
+            if(!in_array($filterDisabled, $disabledDays)) {
+              $iteration += 1;
+            }
+            return $this->edw_get_working_day_date($disabledDays, $daysToAdd, $dateCheck, $iteration);
+        }
 
         private function edw_get_date($disabledDays, $daysEstimated, $dateCheck = false){
             if(count($disabledDays) == 7) {
@@ -413,10 +430,13 @@ if(!defined('EDWCore')) {
                     $maxDays += 1;
                 }
             }
-            
-            
-            $minDate = $this->edw_get_date($disabledDays, $days);
-            $maxDate = $this->edw_get_date($disabledDays, $maxDays);            
+
+            $today = wp_date('Y-m-d');
+            $minDate = $this->edw_get_working_day_date($disabledDays, $days, $today);
+            if($minDate) {
+              $dateDiff = $maxDays - $days;
+              $maxDate = $this->edw_get_working_day_date($disabledDays, $dateDiff, $minDate);
+            }
 
             if($minDate && $maxDate) {
                 $date_format = get_option('date_format');


### PR DESCRIPTION
While using this plugin, I noticed the calculations for delivery date ranges were always using absolute days, and the result wasn't always correct. I would expect delivery dates to be calculated only using working days, and the maximum shipping date to be based on a previously calculated start date.

I believe it was also reported here: https://github.com/DanielRiera/estimated-delivery-woocommerce/issues/41

I made the following changes:
- only working days are taken into account when calculating delivery range;
- maximum shipping date is always calculated based on minimum shipping date.

**Example:**
Shipping of my products take 2 to 3 business days. Delivery company doesn't work on Saturdays and Sundays. When users visit my website on Friday, they should see expected delivery on Tuesday-Wednesday next week, but they were shown Monday date only.

This happens because both minimum shipping date and maximum shipping date are calculated independently from each other. Minimum delivery time is 2 days, but Friday + 2 days is Sunday; minimum date is then bumped to Monday. Then, max date is Friday + 3 days: Monday again.

| M | T | W | T | F | S | S |
|---|---|---|---|---|---|---|
|   |   |   |   | today | x | x |
| 1 | 2 | 3 |   |   |   |   |

**Example 2:**
Some products are made to order and take up to 10 working days to deliver. Deliveries are not made on weekends. If today is Wednesday, the maximum delivery date is another Wednesday in two weeks - it's calculated as follows:
| M | T | W  | T | F | S | S |
|---|---|----|---|---|---|---|
|   |   |  today  | 1 | 2 | x | x |
| 3 | 4 | 5  | 6 | 7 | x | x |
| 8 | 9 | 10 |   |   |   |   |